### PR TITLE
fixed tests. ignoring hash names for deployments

### DIFF
--- a/internal/controller/basicauthenticator_controller.go
+++ b/internal/controller/basicauthenticator_controller.go
@@ -172,6 +172,7 @@ func (r *BasicAuthenticatorReconciler) Reconcile(ctx context.Context, req ctrl.R
 			}
 		} else {
 			//update deployment
+
 			if !reflect.DeepEqual(newDeployment.Spec, foundDeployment.Spec) {
 				logger.Info("updating deployment")
 				foundDeployment.Spec = newDeployment.Spec
@@ -201,6 +202,7 @@ func (r *BasicAuthenticatorReconciler) SetupWithManager(mgr ctrl.Manager) error 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&authenticatorv1alpha1.BasicAuthenticator{}).
 		Owns(&appv1.Deployment{}).
+		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Secret{}).
 		Complete(r)
 }

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -5,4 +5,4 @@ testDirs:
 crdDir: ./config/crd/bases
 kindContext: kind
 startKIND: false
-timeout: 120
+timeout: 60

--- a/tests/e2e/deployment/00-assert.yaml
+++ b/tests/e2e/deployment/00-assert.yaml
@@ -4,13 +4,3 @@ metadata:
   name: basicauthenticator-sample
 status:
   readyReplicas: 1
----
-apiVersion: apps/v1
-kind: deployment
-metadata:
-  name: basicauthenticator-sample-nginx
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: basicauthenticator-sample-credentials

--- a/tests/e2e/deployment/00-install.yaml
+++ b/tests/e2e/deployment/00-install.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   type: deployment
   replicas: 1
-  appPort: 8080
-  appService: test.ns.svc
+  appPort: 8081
+  appService: google.com
   adaptiveScale: false
   authenticatorPort: 8080

--- a/tests/e2e/deployment/01-assert.yaml
+++ b/tests/e2e/deployment/01-assert.yaml
@@ -1,9 +1,3 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: basicauthenticator-sample-nginx
-spec:
-  replicas: 3
 ---
 apiVersion: authenticator.snappcloud.io/v1alpha1
 kind: BasicAuthenticator


### PR DESCRIPTION
by changing the logic of naming deployments and configmaps, tests needed to be revised

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the authentication controller to manage associated configuration more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->