### PR TITLE
renamed basicauth prefix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Wait for basic operator to be ready
         run: |
-          kubectl wait --for=condition=available --timeout=300s deployment.apps/basicauthenticator-controller-manager -n basicauthenticator-system
-          kubectl wait --for=condition=ContainersReady --timeout=300s pods -n basicauthenticator-system --selector=control-plane=controller-manager
+          kubectl wait --for=condition=available --timeout=300s deployment.apps/simpleauthenticator-controller-manager -n basicauthenticator-system
+          kubectl wait --for=condition=ContainersReady --timeout=300s pods -n simpleauthenticator-system --selector=control-plane=controller-manager
       - name: Run e2e test
         run: make e2e-test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Wait for basic operator to be ready
         run: |
-          kubectl wait --for=condition=available --timeout=300s deployment.apps/simpleauthenticator-controller-manager -n basicauthenticator-system
+          kubectl wait --for=condition=available --timeout=300s deployment.apps/simpleauthenticator-controller-manager -n simpleauthenticator-system
           kubectl wait --for=condition=ContainersReady --timeout=300s pods -n simpleauthenticator-system --selector=control-plane=controller-manager
       - name: Run e2e test
         run: make e2e-test

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# snappcloud.io/basicauthenticator-bundle:$VERSION and snappcloud.io/basicauthenticator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= snappcloud.io/basicauthenticator
+# snappcloud.io/simpleauthenticator-bundle:$VERSION and snappcloud.io/simpleauthenticator-catalog:$VERSION.
+IMAGE_TAG_BASE ?= snappcloud.io/simpleauthenticator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
@@ -299,4 +299,4 @@ $(HELMIFY): $(LOCALBIN)
 	test -s $(LOCALBIN)/helmify || GOBIN=$(LOCALBIN) go install github.com/arttor/helmify/cmd/helmify@latest
 
 helm: manifests kustomize helmify
-	$(KUSTOMIZE) build config/default | $(HELMIFY) deploy/charts/simple-authenticator
+	$(KUSTOMIZE) build config/default | $(HELMIFY) charts/simple-authenticator

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# basicauthenticator
+# simpleauthenticator
 // TODO(user): Add simple overview of use/purpose
 
 ## Description

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: basicauthenticator-system
+namespace: simpleauthenticator-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: basicauthenticator-
+namePrefix: simpleauthenticator-
 
 # Labels to add to all resources and selectors.
 #labels:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated Kubernetes resource names in CI/CD workflows for better alignment with the new module name.
- **Chores**
	- Modified the `Makefile` to use a new image tag base and updated the path for the `helmify` command.
- **Documentation**
	- Updated the README to reflect the renaming of the module from "basicauthenticator" to "simpleauthenticator".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->